### PR TITLE
Fix shell is not loading issue.

### DIFF
--- a/src/main/kotlin/com/embabel/DeckerApplication.kt
+++ b/src/main/kotlin/com/embabel/DeckerApplication.kt
@@ -26,12 +26,12 @@ import org.springframework.boot.runApplication
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableAgentShell
 @EnableAgents(
     loggingTheme = LoggingThemes.SEVERANCE,
     localModels = [LocalModels.DOCKER],
     mcpServers = [McpServers.DOCKER, McpServers.DOCKER_DESKTOP],
     )
-@EnableAgentShell
 class DeckerApplication
 
 fun main(args: Array<String>) {


### PR DESCRIPTION
This pull request modifies the annotations in the `DeckerApplication` class to adjust the order of `@EnableAgentShell` for better readability and consistency.

Annotation adjustments:

* [`src/main/kotlin/com/embabel/DeckerApplication.kt`](diffhunk://#diff-e9dd1170c078f24081e8f3df45126fecb324120aefa8a9ba13a10e68ccb0bd7cR29-L34): Moved the `@EnableAgentShell` annotation above the `@EnableAgents` annotation to improve clarity and maintain a logical order of annotations.